### PR TITLE
be compatible with older node versions

### DIFF
--- a/src/format/format-factur-x.service.ts
+++ b/src/format/format-factur-x.service.ts
@@ -1,6 +1,6 @@
 import { Textdomain } from '@esgettext/runtime';
 import { Injectable } from '@nestjs/common';
-import crypto from 'crypto';
+import { webcrypto as crypto } from 'crypto';
 import {
 	AFRelationship,
 	PDFArray,


### PR DESCRIPTION
For Node 18, the webcrypto compatibility mode has to be explicitly enabled.

This fixes #65.