### PR TITLE
use .nojekyll as filename

### DIFF
--- a/packages/docs/_qgoda.yaml
+++ b/packages/docs/_qgoda.yaml
@@ -27,8 +27,8 @@ pre-build:
     run: npm run build
 # See https://github.com/peaceiris/actions-gh-pages/issues/892!
 post-build:
-  - name: exists
-    run: touch _site/e-invoice-eu/.exists
+  - name: disable-jekyll 
+    run: touch _site/e-invoice-eu/.nojekyll
 defaults:
   - files:
       - /*/**


### PR DESCRIPTION
This fixes two problems at once. It disables Jekyll and also fixes the problem with the missing hidden file.